### PR TITLE
A1 motion retarget config + binary tweaks.

### DIFF
--- a/retarget_motion/retarget_config_a1.py
+++ b/retarget_motion/retarget_config_a1.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+URDF_FILENAME = "a1/a1.urdf"
+
+REF_POS_SCALE = 0.825
+INIT_POS = np.array([0, 0, 0.32])
+INIT_ROT = np.array([0, 0, 0, 1.0])
+
+SIM_TOE_JOINT_IDS = [
+    5,  # right hand
+    15,  # right foot
+    10,  # left hand
+    20,  # left foot
+]
+SIM_HIP_JOINT_IDS = [1, 11, 6, 16]
+SIM_ROOT_OFFSET = np.array([0, 0, -0.06])
+SIM_TOE_OFFSET_LOCAL = [
+    np.array([0, -0.05, 0.0]),
+    np.array([0, -0.05, 0.01]),
+    np.array([0, 0.05, 0.0]),
+    np.array([0, 0.05, 0.01])
+]
+
+DEFAULT_JOINT_POSE = np.array([0, 0.9, -1.8, 0, 0.9, -1.8, 0, 0.9, -1.8, 0, 0.9, -1.8])
+JOINT_DAMPING = [0.1, 0.05, 0.01,
+                 0.1, 0.05, 0.01,
+                 0.1, 0.05, 0.01,
+                 0.1, 0.05, 0.01]
+
+FORWARD_DIR_OFFSET = np.array([0, 0, 0])

--- a/retarget_motion/retarget_motion.py
+++ b/retarget_motion/retarget_motion.py
@@ -1,7 +1,14 @@
+"""Run from motion_imitation/retarget_motion to find data correctly."""
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+import inspect
+currentdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+parentdir = os.path.dirname(currentdir)
+os.sys.path.insert(0, parentdir)
 
 import time
 
@@ -14,6 +21,7 @@ import pybullet
 import pybullet_data as pd
 from motion_imitation.utilities import motion_util
 
+# import retarget_config_a1 as config
 import retarget_config_laikago as config
 # import retarget_config_vision60 as config
 
@@ -330,6 +338,8 @@ def main(argv):
     
       ground = pybullet.loadURDF(GROUND_URDF_FILENAME)
       robot = pybullet.loadURDF(config.URDF_FILENAME, config.INIT_POS, config.INIT_ROT)
+      # Set robot to default pose to bias knees in the right direction.
+      set_pose(robot, np.concatenate([config.INIT_POS, config.INIT_ROT, config.DEFAULT_JOINT_POSE]))
 
       p.removeAllUserDebugItems()
       print("mocap_name=", mocap_motion[0])


### PR DESCRIPTION
* Added retarget_config_a1.py to enable retargeting dog motions to A1
robot.

* Set robot to its default pose before retargeting. The inverse
kinematics starts from the robot's current pose, so this biases it to
get the knees bending in the right direction.

* Added motion_imitation to the path. Without this the motion_util
import fails.