### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Project page: https://xbpeng.github.io/projects/Robotic_Imitation/index.html
 
 ## Getting Started
 
-We use this repository with Python 3.7 or Python 3.8 on Ubuntu, MacOS and Windows.
+We use this repository with Python 3.7 on Ubuntu, MacOS and Windows.
 
 - Install MPC extension (Optional) `python3 setup.py install --user`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ tensorflow==1.15.4
 tensorboard==1.15.0
 typing==3.7.4.1
 stable-baselines==2.10.0
+protobuf==3.20
 tqdm
 numba
 quadprog


### PR DESCRIPTION
Remove misleading Python 3.8 statement from installation instructions. Python3.8 pip cannot install tensorflow1.x. 

And it will stay that way:
**https://github.com/tensorflow/tensorflow/issues/39768#issuecomment-632799481**